### PR TITLE
Add SoilProfile constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SoilProfiles"
 uuid = "d2d87a28-bc46-4564-bd1b-2e333645c2dc"
 authors = ["Andrew G. Brown <andrew.g.brown@usda.gov>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/README.md
+++ b/README.md
@@ -20,13 +20,20 @@ l = DataFrame(pid = [1,1,1,1,1,2,2,2,2,2,3,3,3,3,3],
               bot = [10,20,30,40,50,5,10,15,20,25,20,40,60,80,100])
 
 # Construct a SoilProfile from DataFrames
-#  Must specify: 
+#  Must specify:
 #  - unique profile ID
 #  - top and bottom depth column names in layer DataFrame
 #  - site DataFrame and layer DataFrame
 
-spc = SoilProfile("pid", ["top", "bot"], s, l)
-show(spc)
+sp1 = SoilProfile("pid", ["top", "bot"], s, l)
+
+# equivalent syntax
+# when ID specified as argument
+sp2 = SoilProfile("pid", s, l)
+# or when ID as first column in site data
+sp3 = SoilProfile(s, l)
+
+show(sp1)
 
 # empty SoilProfile
 show(SoilProfile())
@@ -53,10 +60,10 @@ checkTopology(res)
 show(spc[1,1])
 
 # iterate using for i in SoilProfile
-for i in spc
+for i in sp1
  show(i)
 end
 
 # or use foreach(::Function, ::SoilProfile)
-foreach(show, spc)
+foreach(show, sp1)
 ```

--- a/src/SoilProfiles.jl
+++ b/src/SoilProfiles.jl
@@ -1,6 +1,6 @@
 module SoilProfiles
 
-    greet() = print("SoilProfiles v0.2.0")
+    greet() = print("SoilProfiles v0.2.1\n")
 
     using DataFrames
     import Base.show, Base.length, Base.size, Base.iterate,
@@ -22,6 +22,18 @@ module SoilProfiles
                                 DataFrame(pid = Int64[],
                                           top = Int64[], bot = Int64[]))
 
+    # 0.1.x: backward compatibility: first two non-ID columns in layers become top/bottom
+    SoilProfile(pid::String,
+                sites::DataFrame,
+                layers::DataFrame) = SoilProfile(pid,
+                                                 names(layers)[findall(names(layers) .!= pid)],
+                                                 sites, layers)
+
+    # 0.2.1+: even simpler: site id first in first column, first two non-ID columns in layers become top/bottom
+    SoilProfile(sites::DataFrame,
+                layers::DataFrame) =  SoilProfile(names(sites)[1],
+                                                  names(layers)[findall(names(layers) .!= names(sites)[1])],
+                                                  sites, layers)
     # site and layer accessor methods
     site(p::SoilProfile) = p.site
     layer(p::SoilProfile) = p.layer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,18 @@ end
     @test isValid(spc3) == true
     @test isempty(SoilProfile()) == true
     @test isValid(SoilProfile()) == true
+
+    # valid ways of constructing from data frames where:
+    # - first column in site data contains site id (or pid specified)
+    # - first two non-ID columns in layers contain top and bottom depth
+    s = DataFrame(pid = 1:3, elev = 100:102)
+    l = DataFrame(pid = [1,1,1,1,1,2,2,2,2,2,3,3,3,3,3],
+                  top = [0,10,20,30,40,0,5,10,15,20,0,20,40,60,80],
+                  bot = [10,20,30,40,50,5,10,15,20,25,20,40,60,80,100])
+    @test isValid(SoilProfile("pid", ["top", "bot"], s, l))
+    @test isValid(SoilProfile("pid", s, l))
+    @test isValid(SoilProfile(s, l))
+
     show(spc)
 end
 


### PR DESCRIPTION
- Backwards compatible with 0.1.x 
```julia 
SoilProfile(pid::String, sites::DataFrame, layers::DataFrame)
```
- Full 0.2+ 
```julia 
SoilProfile(pid::String, depthnames::Vector{String}, sites::DataFrame, layers::DataFrame)
```
- Simplified 0.2.1+ 
```julia 
SoilProfile(sites::DataFrame, layers::DataFrame)
```